### PR TITLE
Stub api calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :test do
   gem 'webdrivers'
   gem 'simplecov', '0.17.1'
   gem 'simplecov-console'
+  gem 'webmock'
   gem 'travis'
   
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       xpath (~> 3.2)
     childprocess (3.0.0)
     concurrent-ruby (1.1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.6)
     devise (4.7.1)
       bcrypt (~> 3.0)
@@ -101,6 +103,7 @@ GEM
       net-http-pipeline
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (1.0.1)
     highline (1.7.10)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
@@ -199,6 +202,7 @@ GEM
     rspec-support (3.9.2)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
+    safe_yaml (1.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.2.1)
@@ -265,6 +269,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (4.2.2)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -303,6 +311,7 @@ DEPENDENCIES
   tzinfo-data
   web-console (>= 3.3.0)
   webdrivers
+  webmock
   webpacker (~> 4.0)
 
 RUBY VERSION

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= csp_meta_tag %>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'https://maps.googleapis.com/maps/api/js?key='+ Rails.application.credentials.google_maps_API_key + '&libraries=places' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= yield(:head_tags) %>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
     <%= csp_meta_tag %>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'https://maps.googleapis.com/maps/api/js?key='+ Rails.application.credentials.google_maps_API_key + '&libraries=places' %>
+    <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{Rails.application.credentials.google_maps_API_key || ""}&libraries=places" %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= yield(:head_tags) %>
   </head>

--- a/app/views/routes/new.html.erb
+++ b/app/views/routes/new.html.erb
@@ -1,5 +1,5 @@
 <% provide :head_tags do %>
-<%= javascript_include_tag 'https://maps.googleapis.com/maps/api/js?key='+ Rails.application.credentials.google_maps_API_key + '&libraries=places' %>
+
     <meta name='turbolinks-visit-control' content='reload'>
     <script>
     document.addEventListener('DOMContentLoaded', function(){

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -2,7 +2,6 @@
   <%= javascript_include_tag 'https://maps.googleapis.com/maps/api/js?key='+Rails.application.credentials.google_maps_API_key %>
   <meta name='turbolinks-visit-control' content='reload'>
   <script>
-    
     document.addEventListener("DOMContentLoaded", function(){
       var route = []
       <%@places.each do |x|%>
@@ -10,8 +9,6 @@
       <%end%>
       initMap(route)
     });
-  });
-
   </script>
 
 <% end %>

--- a/app/views/routes/show.html.erb
+++ b/app/views/routes/show.html.erb
@@ -1,5 +1,4 @@
 <% provide :head_tags do %>
-  <%= javascript_include_tag 'https://maps.googleapis.com/maps/api/js?key='+Rails.application.credentials.google_maps_API_key %>
   <meta name='turbolinks-visit-control' content='reload'>
   <script>
     document.addEventListener("DOMContentLoaded", function(){

--- a/spec/features/external_requests_spec.rb
+++ b/spec/features/external_requests_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.feature 'Sign in', type: :feature do
+  scenario 'External request' do
+    uri = URI('https://maps.googleapis.com/maps/api/js')
+
+    response = Net::HTTP.get(uri)
+
+    expect(response).to be_an_instance_of(String)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,10 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'webhelpers'
 require 'simplecov'
+require 'webmock/rspec'
+#disable external calls in tests
+WebMock.disable_net_connect!(allow_localhost: true)
+
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::Console,
   SimpleCov::Formatter::HTMLFormatter
@@ -62,6 +66,12 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
+  config.before(:each) do
+    stub_request(:get, /maps.googleapis.com/).
+      with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+      to_return(status: 200, body: "stubbed response", headers: {})
+  end
+  
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:


### PR DESCRIPTION
This branch takes the first step in passing travis rspec tests where Rails.credentials is nil.

Have also blocked external api calls in tests using gem 'webmocker'. A general googleapi call stub has been set up in rails_helper to mock api calls, but we may need to set up more complex stubs for create route which relies on receiving information from the api to submit routes.